### PR TITLE
set lowPriorityIndicator to undefined if it is present

### DIFF
--- a/src/cgf_gprs.erl
+++ b/src/cgf_gprs.erl
@@ -560,8 +560,8 @@ sgsn_pdp_record15(SGSNPDPRecord, Acc) ->
 	sgsn_pdp_record16(SGSNPDPRecord, Acc).
 %% @hidden
 sgsn_pdp_record16(#{lowPriorityIndicator
-		:= LowPriorityIndicator} = SGSNPDPRecord, Acc) ->
-	Acc1 = Acc#{<<"lowPriorityIndicator">> => LowPriorityIndicator},
+		:= _LowPriorityIndicator} = SGSNPDPRecord, Acc) ->
+	Acc1 = Acc#{<<"lowPriorityIndicator">> => undefined},
 	sgsn_pdp_record17(SGSNPDPRecord, Acc1);
 sgsn_pdp_record16(SGSNPDPRecord, Acc) ->
 	sgsn_pdp_record17(SGSNPDPRecord, Acc).


### PR DESCRIPTION
set lowPriorityIndicator field to undefined if it is present in the import else do not include lowPriorityIndicator in CDR